### PR TITLE
Add bz2 compression of pickle

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -3,6 +3,7 @@ import logging as log
 import numpy as np
 import os.path
 import pickle
+import bz2
 import third_party.humblerl as hrl
 
 from functools import partial
@@ -74,11 +75,13 @@ class CMAES:
         return self.es.result[0]  # best evaluated solution
 
     def save_ckpt(self, path):
-        pickle.dump(self, open(os.path.abspath(path), 'wb'))
-
+        with bz2.BZ2File(os.path.abspath(path), 'w') as f:
+            pickle.dump(self, f)
+            
     @staticmethod
     def load_ckpt(path):
-        return pickle.load(open(os.path.abspath(path), 'rb'))
+        with bz2.BZ2File(os.path.abspath(path), 'r') as f:
+            return pickle.load(f)
 
 
 class Evaluator(Worker):


### PR DESCRIPTION
Ponieważ obiekt klasy cmaes zawiera instancję klasy CMAEvolutionStrategy, która również przechowuje stan, nie wchodziło w grę żadne zrzucanie do arraya. Skorzystałem natomiast z kompresji picklowania.

Czas ładowania/waga modelu cmaes z populacją:
pickle:1.9s/382MB
bz2:6.5s/12MB
gzip:6.3s/15MB

Ostatecznie wybrałem bz2, jest oczywiście spory trade-off